### PR TITLE
Fixed testScriptPresent()

### DIFF
--- a/SnapPLE.js
+++ b/SnapPLE.js
@@ -1179,7 +1179,14 @@ function occurancesOfBlockSpec(blockSpec, block) {
  *
  */
 function scriptsMatch(template, script, softMatch, vars, templateVariables) {
-	var morph1, morph2, type1, type2;
+	var morph1, morph2, type1, type2, templateIsArray, scriptIsArray;
+	templateIsArray = (Object.prototype.toString.call(template) === '[object Array]');
+	scriptIsArray = (Object.prototype.toString.call(script) === '[object Array]');
+	if (templateIsArray && scriptIsArray) {
+		if (template.length !== script.length) {
+			return false;
+		}
+	}
 	for (var i = 0; i < template.length; i++) {
 		morph1 = template[i];
 		morph2 = script[i];

--- a/SnapPLE.js
+++ b/SnapPLE.js
@@ -398,13 +398,24 @@ function testScriptPresent(scriptString, scriptVariables, spriteIndex, outputLog
 	if (spriteIndex === undefined) {
 		spriteIndex = 0;
 	}
-	
+
 	var JSONtemplate = stringToJSON(scriptString);
 	var blockSpec = JSONtemplate[0].blockSp;
 	var testID = outputLog.addTest("p", blockSpec, "n/a", true, -1);
 	//Handle case when no scripts present on stage.
 	try {
-		var JSONtarget = JSONscript(getScript(blockSpec, spriteIndex));
+		var JSONtarget;
+		var scriptsOnScreen = getAllScript(blockSpec, spriteIndex);
+		var isPresent;
+		for (var i = 0; i < scriptsOnScreen.length; i++) {
+			JSONtarget = JSONscript(scriptsOnScreen[i]);
+			if (JSONtarget[0].blockSp === blockSpec) {
+				isPresent = checkTemplate(JSONtemplate, JSONtarget, scriptVariables);
+				if (isPresent) {
+					break;
+				}
+			}
+		}
 	} catch(e) {
 		var isPresent = false;
 		var feedback = "Script Missing: The target script was not found in the scripts tab"
@@ -415,9 +426,6 @@ function testScriptPresent(scriptString, scriptVariables, spriteIndex, outputLog
 		return outputLog;
 	}
 	//test that scripts match
-		//TODO: update scriptsMatch function to take block objects, not objects on screen
-	//var isPresent = scriptsMatch(JSONtemplate, JSONtarget, false);
-	var isPresent = checkTemplate(JSONtemplate, JSONtarget, scriptVariables);
 	if (isPresent) {
 		feedback = "The targeted script is present in the scripts tab.";
 	} else {


### PR DESCRIPTION
- Fixed issue where testScriptPresent() did not work if there were other scripts on the screen besides the    target script.
- Fixed issue where testScriptPresent() would return true if the target script was a subset of another larger script on the screen. Returns false for that case now.
