### PR TITLE
Fixed BlockPrecedes()

### DIFF
--- a/AG_D1_T1.html
+++ b/AG_D1_T1.html
@@ -35,14 +35,22 @@
                 "The 'factorial' block is present.",
                 "The 'factorial %num' block was not found on-screen.",
                 "Make sure you name your custom block, 'factorial %num'.");
-            // testAssert(outputLog, CBlockContainsInCustom('factorial %s', 0,
-            //     'if %c else %c', 'report %s'),
-            //     "The factorial block;
+            testAssert(outputLog, customBlockContains('factorial %s', 'factorial %s'),
+                "The 'factorial' block has a recursive call to itself.",
+                "There is no recursive call to 'factorial.",
+                "Make sure you have a recursive call inside of 'factorial.");
+            console.log(blockPrecedes('factorial %s', '%n − %n', getCustomBody('factorial %s', 0)));
+            testAssert(outputLog, blockPrecedes('factorial %s', '%n − %n', getCustomBody('factorial %s', 0)),
+                "The recursive call to'factorial' block contains a minus block",
+                "There is no minus block in the recursive call to 'factorial'.",
+                "Make sure you have a minus block inside of the recursive call.");
             multiTestBlock('factorial %s', 
                 [[0],[1],[2],[4],[5],[10]],
                 [1,1,2,24,120,3628800],
                 [-1,-1,-1,-1,-1,-1],
                 outputLog);
+
+
             // /* KScopeTest */
             // testAssert(outputLog, 
             //     spriteContainsBlock('when %keyHat key pressed', 0, ['space']) &&

--- a/SnapPLE.js
+++ b/SnapPLE.js
@@ -1315,6 +1315,18 @@ function JSONcustomBlock(block) {
 		    variables: JSONinputs};
 }
 
+/* Takes in a string BLOCKSPEC and returns the JSONified version of
+ * the custom block's body.
+ */
+function getCustomBody(blockSpec, spriteIndex) {
+	if (spriteIndex === undefined) {
+		spriteIndex = 0;
+	}
+	var customBlock = getScript(blockSpec, spriteIndex);
+	return JSONcustomBlock(customBlock).body;
+
+}
+
 /* Takes in all scripts for a single Sprite in chronological order
  * and converts it into JSON format. You would need to run something like
  * var script = world.children[0].sprites.contents[0].scripts.children[0];
@@ -1562,6 +1574,9 @@ function customBlockContains(customBlockSpec, blockSpec, argArray, spriteIndex) 
  * would count the (%n + %n) block as coming before the (%n - %n) block.
  */
 function blockPrecedes(block1, block2, script, seen1) {
+	if (seen1 === undefined) {
+		seen1 = false;
+	}
 	var morph1, type1;
 	for (var i = 0; i < script.length; i++) {
 		morph1 = script[i];

--- a/SnapPLE.js
+++ b/SnapPLE.js
@@ -1657,6 +1657,9 @@ function testCBlockContains(block1, block2, spriteIndex, outputLog) {
  * JSONscript(...)
  */
 function ifElseContains(script, clause, block1Spec, argArray1) {
+	if (argArray1 === undefined) {
+        argArray1 = [];
+    }
     if (!scriptContainsBlock(script, "if %b %c else %c")) {
         return false;
     }
@@ -1729,6 +1732,12 @@ function blockPrecedes(block1, block2, script, seen1) {
 			}
 			if (blockPrecedes(block1, block2, morph1.inputs, seen1)) {
 				return true;
+			}
+			if (morph1.blockSp ===  "if %b %c else %c") {
+				if (ifElseContains(script, "if", block1)
+					|| ifElseContains(script, "else", block1)) {
+					seen1 = true;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
That case where say we are checking if a "repeat" block precedes a "move" block, now if the "repeat" block is inside the "if/else" block and the "move" block is outside of the entire "if/else" block (beneath it), it will now return true. Every other case remains the same as before.
